### PR TITLE
Use v2 api

### DIFF
--- a/libtf/logparsers/tf_log_base.py
+++ b/libtf/logparsers/tf_log_base.py
@@ -8,7 +8,7 @@ from libtf.logparsers.tf_exceptions import TFAPIUnavailable
 
 
 class TFLogBase(object):
-    api_endpoint = '/reducer/seen'
+    api_endpoint = '/v2/reducer/seen'
     default_base_uri = "https://api.threshingfloor.io"
     default_ip_query_batch_size = 1000
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open(path.join(here, 'README.rst')) as f:
 
 setup(
     name='libtf',
-    version='0.1.0',
+    version='0.1.1',
     license='MIT',
     author='Threshing Floor Security, LLC',
     author_email='info@threshingfloor.io',


### PR DESCRIPTION
Use v2 of the API, which mainly enforces JSON Schema request validation.