### PR TITLE
Fix regression where some quiet lines were not output

### DIFF
--- a/libtf/logparsers/tests/test_auth_log.py
+++ b/libtf/logparsers/tests/test_auth_log.py
@@ -15,7 +15,8 @@ class TestTFAuthLog(TestCase):
             'Feb 21 00:13:35 localhost sshd[7483]: Accepted password for sally from 192.168.33.1 port 58803 ssh2',
             'Feb 21 08:35:22 localhost sshd[5774]: Failed password for root from 116.31.116.24 port 29160 ssh2',
             'Feb 21 19:19:26 localhost sshd[16153]: Failed password for invalid user zuidberg from 142.0.45.14 port 52772 ssh2',
-            'Feb 21 21:56:12 localhost sshd[3430]: Invalid user test from 10.0.2.2'
+            'Feb 21 21:56:12 localhost sshd[3430]: Invalid user test from 10.0.2.2',
+            'Line that does not match ip regex'
         ], 'foo')
 
     def test_ports_default_to_common_ssh_ports(self):
@@ -66,4 +67,5 @@ class TestTFAuthLog(TestCase):
                 {'timestamp': 1519172015, 'hostname': 'localhost', 'program': 'sshd', 'processid': '7483',
                  'message': 'Accepted password for sally from 192.168.33.1 port 58803 ssh2',
                  'raw': 'Feb 21 00:13:35 localhost sshd[7483]: Accepted password for sally from 192.168.33.1 port 58803'
-                        ' ssh2'}])
+                        ' ssh2'},
+                {'raw': 'Line that does not match ip regex'}])

--- a/libtf/logparsers/tests/test_http_log.py
+++ b/libtf/logparsers/tests/test_http_log.py
@@ -12,7 +12,8 @@ class TestTFHTTPLog(TestCase):
             '192.168.1.10 - - [13/Sep/2006:07:01:53 -0700] "PROPFIND /svn/1234/Extranet/branches/SOW-101 HTTP/1.1"'
             ' 401 587',
             '192.168.1.20 - - [28/Jul/2006:10:27:10 -0300] "GET /cgi-bin/try/ HTTP/1.0" 200 3395',
-            '192.178.1.30 - - [28/Jul/2006:10:27:32 -0300] "GET /hidden/ HTTP/1.0" 404 7218'
+            '192.178.1.30 - - [28/Jul/2006:10:27:32 -0300] "GET /hidden/ HTTP/1.0" 404 7218',
+            'Line that does not match ip regex'
         ], 'foo')
 
     def test_ports_default_to_common_http_ports(self):
@@ -38,5 +39,6 @@ class TestTFHTTPLog(TestCase):
                  'raw': '192.168.1.10 - - [13/Sep/2006:07:01:53 -0700] "PROPFIND /svn/1234/Extranet/branches/SOW-101 '
                         'HTTP/1.1" 401 587'},
                 {'ip': '192.178.1.30',
-                 'raw': '192.178.1.30 - - [28/Jul/2006:10:27:32 -0300] "GET /hidden/ HTTP/1.0" 404 7218'}
+                 'raw': '192.178.1.30 - - [28/Jul/2006:10:27:32 -0300] "GET /hidden/ HTTP/1.0" 404 7218'},
+                {'raw': 'Line that does not match ip regex'}
             ])

--- a/libtf/logparsers/tests/test_tf_generic_log.py
+++ b/libtf/logparsers/tests/test_tf_generic_log.py
@@ -11,7 +11,8 @@ class TestTFGenericLog(TestCase):
         self.tf_generic_log = TFGenericLog([
             '192.168.1.10 - - [13/Sep/2006:07:01:53 -0700] foo bar baz',
             '192.168.1.20 - - [28/Jul/2006:10:27:10 -0300] foo bar baz',
-            '192.178.1.30 - - [28/Jul/2006:10:27:32 -0300] foo bar baz'
+            '192.178.1.30 - - [28/Jul/2006:10:27:32 -0300] foo bar baz',
+            'Line that does not match ip regex'
         ], 'foo', ports=['123:udp'])
 
     def test_ports_must_be_specified(self):
@@ -35,5 +36,6 @@ class TestTFGenericLog(TestCase):
                 {'ip': '192.168.1.10',
                  'raw': '192.168.1.10 - - [13/Sep/2006:07:01:53 -0700] foo bar baz'},
                 {'ip': '192.178.1.30',
-                 'raw': '192.178.1.30 - - [28/Jul/2006:10:27:32 -0300] foo bar baz'}
+                 'raw': '192.178.1.30 - - [28/Jul/2006:10:27:32 -0300] foo bar baz'},
+                {'raw': 'Line that does not match ip regex'}
             ])

--- a/libtf/logparsers/tf_auth_log.py
+++ b/libtf/logparsers/tf_auth_log.py
@@ -68,7 +68,7 @@ class TFAuthLog(TFLogBase):
         for parsed_line in self.parsed_lines:
 
             # If it's ssh, we can handle it
-            if parsed_line['program'] == 'sshd':
+            if parsed_line.get('program') == 'sshd':
                 result = self._parse_auth_message(parsed_line['message'])
 
                 # Add the ip if we have it
@@ -90,16 +90,21 @@ class TFAuthLog(TFLogBase):
         """
         for line in self.line_iterator:
             m = COMPILED_AUTH_LOG_REGEX.match(line)
+
+            data = {
+                'raw': line
+            }
+
             if m:
-                data = {
+                data.update({
                     'timestamp': self._to_epoch(m.group(1)),
                     'hostname': m.group(2),
                     'program': m.group(3),
                     'processid': m.group(4),
                     'message': m.group(5),
-                    'raw': line
-                }
-                self.parsed_lines.append(data)
+                })
+
+            self.parsed_lines.append(data)
 
     def _analyze(self):
         """
@@ -113,7 +118,7 @@ class TFAuthLog(TFLogBase):
                     pids.append(pid)
 
         for line in self.parsed_lines:
-            if line['processid'] in pids:
+            if 'processid' in line and line['processid'] in pids:
                 self.noisy_logs.append(line)
             else:
                 self.quiet_logs.append(line)

--- a/libtf/logparsers/tf_generic_log.py
+++ b/libtf/logparsers/tf_generic_log.py
@@ -32,12 +32,15 @@ class TFGenericLog(TFLogBase):
         """
         for line in self.line_iterator:
             m = re.search(GENERIC_IPV4_REGEX, line)
+
+            data = {
+                'raw': line
+            }
+
             if m:
-                data = {
-                    'ip': m.group('ip'),
-                    'raw': line
-                }
-                self.parsed_lines.append(data)
+                data['ip'] = m.group('ip')
+
+            self.parsed_lines.append(data)
 
     def _extract_features(self):
         """
@@ -46,6 +49,7 @@ class TFGenericLog(TFLogBase):
         for parsed_line in self.parsed_lines:
             result = {'raw': parsed_line}
 
-            result['ip'] = parsed_line['ip']
-            if result['ip'] not in self.features['ips']:
-                self.features['ips'].append(result['ip'])
+            if 'ip' in parsed_line:
+                result['ip'] = parsed_line['ip']
+                if result['ip'] not in self.features['ips']:
+                    self.features['ips'].append(result['ip'])

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open(path.join(here, 'README.rst')) as f:
 
 setup(
     name='libtf',
-    version='0.1.1',
+    version='0.1.2',
     license='MIT',
     author='Threshing Floor Security, LLC',
     author_email='info@threshingfloor.io',


### PR DESCRIPTION
Fixes a regression, introduced in 0.1.0, where lines not matching an IP regex would not be output as quiet lines.